### PR TITLE
Convert the test file to use unit tests.

### DIFF
--- a/rotten_tomatoes_scraper/test_scraper.py
+++ b/rotten_tomatoes_scraper/test_scraper.py
@@ -1,8 +1,9 @@
 from bs4 import BeautifulSoup
 import re
 from urllib.request import urlopen
+import unittest
 
-from rotten_tomatoes_scraper.rt_scraper import CelebrityScraper, MovieScraper
+from rt_scraper import CelebrityScraper, MovieScraper
 
 
 class WikiParser:
@@ -30,54 +31,55 @@ class WikiParser:
         return actors
 
 
-def test_celebrity_scraper_01():
-    celebrity_scraper = CelebrityScraper(celebrity_name='jack nicholson')
-    celebrity_scraper.extract_metadata(section='filmography')
-    movie_titles = celebrity_scraper.metadata['movie_titles']
-    assert 'The Departed' in movie_titles
+class TestRtParser(unittest.TestCase):
+    def test_celebrity_scraper_01(self):
+        celebrity_scraper = CelebrityScraper(celebrity_name='jack nicholson')
+        celebrity_scraper.extract_metadata(section='filmography')
+        movie_titles = celebrity_scraper.metadata['movie_titles']
+        self.assertIn('The Departed', movie_titles)
 
 
-def test_celebrity_scraper_02():
-    celebrity_scraper = CelebrityScraper(celebrity_name='meryl streep')
-    celebrity_scraper.extract_metadata(section='highest')
-    movie_titles = celebrity_scraper.metadata['movie_titles']
-    assert 'Manhattan' in movie_titles
+    def test_celebrity_scraper_02(self):
+        celebrity_scraper = CelebrityScraper(celebrity_name='meryl streep')
+        celebrity_scraper.extract_metadata(section='highest')
+        movie_titles = celebrity_scraper.metadata['movie_titles']
+        self.assertIn('Manhattan', movie_titles)
 
 
-def test_celebrity_scraper_03():
-    wiki_parser = WikiParser()
-    actresses = wiki_parser.extract_actresses_names()
-    celebrity_scraper = CelebrityScraper(celebrity_name=actresses[2])
-    celebrity_scraper.extract_metadata(section='highest')
-    movie_titles = celebrity_scraper.metadata['movie_titles']
-    assert 'Manhattan' in movie_titles
+    def test_celebrity_scraper_03(self):
+        wiki_parser = WikiParser()
+        actresses = wiki_parser.extract_actresses_names()
+        celebrity_scraper = CelebrityScraper(celebrity_name=actresses[2])
+        celebrity_scraper.extract_metadata(section='highest')
+        movie_titles = celebrity_scraper.metadata['movie_titles']
+        self.assertIn('Manhattan', movie_titles)
+
+    def test_movie_scraper_01(self):
+        movie_scraper = MovieScraper(movie_title='Manhattan')
+        movie_scraper.extract_metadata()
+        movie_genres = movie_scraper.movie_genre
+        self.assertIn('kidsandfamily', movie_genres)
 
 
-def test_movie_scraper_01():
-    movie_scraper = MovieScraper(movie_title='Manhattan')
-    movie_scraper.extract_metadata()
-    movie_genres = movie_scraper.movie_genre
-    assert 'Kids&Family' or 'kidsandfamily' in movie_genres
+    def test_movie_scraper_02(self):
+        movie_url = 'https://www.rottentomatoes.com/m/manhattan'
+        movie_scraper = MovieScraper(movie_url=movie_url)
+        movie_scraper.extract_metadata()
+        movie_genres = movie_scraper.movie_genre
+        self.assertNotIn('Kids&Family', movie_genres)
 
 
-def test_movie_scraper_02():
-    movie_url = 'https://www.rottentomatoes.com/m/manhattan'
-    movie_scraper = MovieScraper(movie_url=movie_url)
-    movie_scraper.extract_metadata()
-    movie_genres = movie_scraper.movie_genre
-    assert 'Kids&Family' not in movie_genres
+    def test_movie_scraper_03(self):
+        movie_url = 'https://www.rottentomatoes.com/m/marriage_story_2019'
+        movie_scraper = MovieScraper(movie_url=movie_url)
+        movie_scraper.extract_metadata()
+        self.assertEqual(movie_scraper.metadata['Rating'], 'R')
 
 
-def test_movie_scraper_03():
-    movie_url = 'https://www.rottentomatoes.com/m/marriage_story_2019'
-    movie_scraper = MovieScraper(movie_url=movie_url)
-    movie_scraper.extract_metadata()
-    print(movie_scraper.metadata)
+    def test_movie_scraper_04(self):
+        movie_scraper = MovieScraper(movie_title='VICKY CRISTINA BARCELONA')
+        movie_scraper.extract_metadata()
+        print(movie_scraper.metadata)
 
-
-def test_movie_scraper_04():
-    movie_scraper = MovieScraper(movie_title='VICKY CRISTINA BARCELONA')
-    movie_scraper.extract_metadata()
-    print(movie_scraper.metadata)
-
-test_celebrity_scraper_03()
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Unit tests are handy because they give clearer error messages, and can run all the tests at once.